### PR TITLE
Rubocop: Allow has_and_belongs_to_many

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,3 +94,7 @@ Style/SymbolArray:
 # Okay to use Rails.root.join('tmp', 'caching-dev.txt')
 Rails/FilePath:
   Enabled: false
+
+# Okay to use has_and_belongs_to_many for many-to-many relationships
+Rails/HasAndBelongsToMany:
+  Enabled: false


### PR DESCRIPTION
`has_and_belongs_to_many` allows you to make the association for many-to-many-relationships directly.

> When using has_and_belongs_to_manyrubocop warns you to use has_many :through which makes the association indirectly, through a join model.

> For instance, we would have to introduce an extra model for mapping room and wall ids when using has_many_through

> This is only recommended when you need to work with the relationship model as an independent entity.

- [difference between has_many :through and has_and_belongs_to_many with example](https://guides.rubyonrails.org/association_basics.html#choosing-between-has-many-through-and-has-and-belongs-to-many)
- [rubocop documentation for has_and_belongs_to_many](https://www.rubydoc.info/gems/rubocop/0.27.0/RuboCop/Cop/Rails/HasAndBelongsToMany)