### PR TITLE
Update rubocop to be less restrictive

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,14 +15,16 @@ AllCops:
 
 # Okay to have long examples in feature tests, there are usually many steps
 RSpec/ExampleLength:
-  Exclude:
-    - 'spec/features/*.rb'
+  Enabled: false
 
 # Okay to have more than one expectation in a single block, default: 1
 RSpec/MultipleExpectations:
-  Max: 2
-  Exclude:
-    - 'spec/features/*.rb'
+  Enabled: false
+  
+# Using instance variables might make tests fail based on their order.
+RSpec/InstanceVariable:
+   AssignmentOnly: true
+   Enabled: true
 
 # Ignore LineLength for config files (e.g. with long secret strings)
 Layout/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,11 +13,11 @@ AllCops:
 # Specific excludes & includes
 #
 
-# Okay to have long examples in feature tests, there are usually many steps
+# Okay to have long examples
 RSpec/ExampleLength:
   Enabled: false
 
-# Okay to have more than one expectation in a single block, default: 1
+# Okay to have more than one expectation in a single block
 RSpec/MultipleExpectations:
   Enabled: false
   

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ RSpec/ExampleLength:
 # Okay to have more than one expectation in a single block
 RSpec/MultipleExpectations:
   Enabled: false
-  
+
 # Using instance variables might make tests fail based on their order.
 RSpec/InstanceVariable:
    AssignmentOnly: true


### PR DESCRIPTION
- disables length restriction of tests
- disables maximum number of expects in tests
- sets the InstanceVariable check to only throw if assigned (for background see: https://tomdebruijn.com/posts/ruby-rspec-instance-variables/)