### PR TITLE
Update workflow to fix CI runner

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7 # Not needed with a .ruby-version file
+          ruby-version: 2.7.4 # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Setup yarn dependencies


### PR DESCRIPTION
Siehe Teams:

> Vor kurzer zeit (am 24.11.) wurde eine neue Version von Ruby 2.7, nämlich 2.7.5, released. Die momentane Config der Übung versucht die neueste 2.7 Version zu installieren, die allerdings in den GitHub Runners noch nicht verfügbar ist.
>
> So könnt ihr das beheben: https://github.com/hpi-swt2-exercise/rails-intro-exercise/commit/f0da9f23afe8051a10b6afd8fd68c2c5690f7e4b



