### PR TITLE
Redesign More Results

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -31,7 +31,7 @@
   }
 
   &.md {
-    width: 6em;
+    width: 4.5em;
   }
 
   &.fill {

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -7,6 +7,40 @@
 @import "colors";
 
 .search-item {
+  border: none !important;
+}
+
+@media only screen and (min-width: 400px) {
+  .search-item {
+    margin-bottom: 0.5rem;
+    border-radius: 1rem !important;
+
+    .col-2, .col {
+      justify-content: center;
+    }
+  }
+}
+
+@media only screen and (max-width: 400px) {
+  .search-item {
+    background-color: transparent !important;
+
+    .search-title {
+      margin-bottom: 0.1rem !important;
+    }
+
+    .col-2, .col {
+      justify-content: start;
+    }
+  
+    .col-2 {
+      padding: 0 !important;
+    }
+  }
+}
+
+
+.search-item {
   &-icon {
     @extend %fa-icon;
     @extend .fas;

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -6,10 +6,6 @@
 
 @import "colors";
 
-.search-item {
-  border: none !important;
-}
-
 @media only screen and (min-width: 400px) {
   .search-item {
     margin-bottom: 0.5rem;
@@ -41,6 +37,8 @@
 
 
 .search-item {
+  border: none !important;
+
   &-icon {
     @extend %fa-icon;
     @extend .fas;

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -31,7 +31,7 @@
                     <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %> 
                   </div>
                   <div class="col mx-3 d-flex flex-column justify-content-center">
-                    <h4><%= result.to_string %></h4>
+                    <h5><%= result.to_string %></h5>
                     <div>
                       <% result.displayed_tags.each do |tag| %>
                         <span class="badge bg-primary"><%= tag %></span>
@@ -44,13 +44,30 @@
             <% end %>
           <% end %>
         </div>
+
+        <br>
+
         <%if @exact_results.present? and @more_results.present? %> More Results <%end %>
         <div class="list-group" id="more-results">
           <%if @more_results.present? %>
             <% @more_results.each do |result|%>
-              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item" >
-              <span class= "<%= result.icon_class %>"></span>
-              <%= result.to_string %></a>
+
+              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
+                <div class='row'>
+                  <div class='col-3 d-flex flex-column justify-content-center'> 
+                    <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %> 
+                  </div>
+                  <div class="col mx-3 d-flex flex-column justify-content-center">
+                    <h5><%= result.to_string %></h5>
+                    <div>
+                      <% result.displayed_tags.each do |tag| %>
+                        <span class="badge bg-primary"><%= tag %></span>
+                      <% end %>
+                    </div>    
+                  </div>
+                </div>
+              </a>
+
             <% end %>
           <% end %>
         </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -47,7 +47,7 @@
 
         <br>
 
-        <%if @exact_results.present? and @more_results.present? %> More Results <%end %>
+        <%if @exact_results.present? and @more_results.present? %> Similar Results <%end %>
         <div class="list-group" id="more-results">
           <%if @more_results.present? %>
             <% @more_results.each do |result|%>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -25,13 +25,13 @@
           <%if @exact_results.present? %>
             <% @exact_results.each do |result|%>
 
-              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action">
+              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
                 <div class='row'>
-                  <div class='col-3 d-flex flex-column justify-content-center'> 
+                  <div class='col-2 d-flex flex-column'>
                     <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %> 
                   </div>
-                  <div class="col mx-3 d-flex flex-column justify-content-center">
-                    <h5><%= result.to_string %></h5>
+                  <div class="col d-flex flex-column my-2">
+                    <h5 class="search-title"><%= result.to_string %></h5>
                     <div>
                       <% result.displayed_tags.each do |tag| %>
                         <span class="badge bg-primary"><%= tag %></span>
@@ -54,11 +54,11 @@
 
               <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
                 <div class='row'>
-                  <div class='col-3 d-flex flex-column justify-content-center'> 
+                  <div class='col-2 d-flex flex-column'>
                     <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %> 
                   </div>
-                  <div class="col mx-3 d-flex flex-column justify-content-center">
-                    <h5><%= result.to_string %></h5>
+                  <div class="col d-flex flex-column my-2">
+                    <h5 class="search-title"><%= result.to_string %></h5>
                     <div>
                       <% result.displayed_tags.each do |tag| %>
                         <span class="badge bg-primary"><%= tag %></span>


### PR DESCRIPTION
Similar results were redesigned according to #163.
Complete redesign in accordance to mockup. Notice how search results have a transparent background in mobile view.

![Screenshot_1](https://user-images.githubusercontent.com/41285083/151199104-e9684ed8-a3c9-4698-bdb0-54fb8383c380.png)

![Screenshot_2](https://user-images.githubusercontent.com/41285083/151199132-7c98fb9f-ffef-492c-8184-b5721588586d.png)

