### PR TITLE
Hotfix sign_out route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,8 @@ Rails.application.routes.draw do
   # '/'
   # Sets `root_url`, devise gem requires this to be set
   devise_scope :user do
-    root to: "users/sessions#new"
+    root to: 'users/sessions#new'
+    get '/users/sign_out', to: 'users/sessions#destroy'
   end
 
   get 'indoor/demo/', to: 'indoor#demo'


### PR DESCRIPTION
Some People were not able to sign_out.
This PR explicitly defines the sign_out route in routes.rb to fix this error and making sure things run smoothly.