### PR TITLE
213 Search Page Design

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -5,6 +5,7 @@
 @import "@fortawesome/fontawesome-free/scss/brands.scss";
 
 @import "colors";
+@import "values";
 
 @media only screen and (min-width: 400px) {
   .search-item {
@@ -86,6 +87,17 @@
   float: right;
   margin-right: 5px;
   visibility: hidden;
+}
+
+/* This is to center the searchbar vertically */
+.searchpage {
+  height: calc(100% - #{$navbar-height});
+}
+
+@media only screen and (max-width: 400px) {
+  .searchpage {
+    height: calc(100% - #{$navbar-height} - #{$titlebar-height});
+  }
 }
 
 @media only screen and (max-width: 400px) {

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -89,15 +89,12 @@
   visibility: hidden;
 }
 
-/* This is to center the searchbar vertically */
-.searchpage {
-  height: calc(100% - #{$navbar-height});
-}
-
-@media only screen and (max-width: 400px) {
-  .searchpage {
-    height: calc(100% - #{$navbar-height} - #{$titlebar-height});
-  }
+/* This is to center the search vertically */
+.search {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 @media only screen and (max-width: 400px) {

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,4 @@
 class SearchController < ApplicationController
-  layout 'fullpage' # This is to center the searchbar vertically
-
   def index
     return if params[:query].nil?
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,6 @@
 class SearchController < ApplicationController
+  layout 'fullpage' # This is to center the searchbar vertically
+
   def index
     return if params[:query].nil?
 

--- a/app/views/partials/_search_bar.html.erb
+++ b/app/views/partials/_search_bar.html.erb
@@ -3,7 +3,8 @@
         <div class="row align-items-end mb-3">
           <div class="col">
             <div class="form-group">
-              <%= form.text_field :query, class: "form-control", autofocus: true, value: @params, id: "search", oninput: "textEntered(this)" %>
+              <%= form.text_field :query, class: "form-control", autofocus: true, value: @params, 
+                id: "search", oninput: "textEntered(this)", placeholder: "Ask me something ..." %>
             </div>
           </div>
         </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,73 +2,71 @@
 
 <%= javascript_pack_tag 'search', 'data-turbolinks-track': 'reload' %>
 <body onload="textEntered();">
-<div class="searchpage d-flex justify-content-center flex-column">
-  <div class="row">
-    <div class="col-lg-6 col-md-9 col-12 mx-auto">
+<div class="row">
+  <div class="col-lg-6 col-md-9 col-12 mx-auto search">
 
-      <div style="text-align:center">
-      <img src="/images/platypus.png" alt="Logo" width="244" height="115">
-      <h2 class="fw-light"></h2>
-      </div>
+    <div style="text-align:center">
+    <img src="/images/platypus.png" alt="Logo" width="244" height="115">
+    <h2 class="fw-light"></h2>
+    </div>
 
-      <%= render('partials/search_bar', :locals => {:path => search_path}) %>
+    <%= render('partials/search_bar', :locals => {:path => search_path}) %>
 
-      <div class="row">
-        <div class="col">
-          <div class="list-group" id="exact-results">
-            <%if @exact_results.present? %>
-              <% @exact_results.each do |result|%>
+    <div class="row">
+      <div class="col">
+        <div class="list-group" id="exact-results">
+          <%if @exact_results.present? %>
+            <% @exact_results.each do |result|%>
 
-                <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
-                  <div class='row'>
-                    <div class='col-2 d-flex flex-column'>
-                      <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
-                    </div>
-                    <div class="col d-flex flex-column my-2">
-                      <h5 class="search-title"><%= result %></h5>
-                      <div>
-                        <% result.displayed_tags.each do |tag| %>
-                          <span class="badge bg-primary"><%= tag %></span>
-                        <% end %>
-                      </div>
+              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
+                <div class='row'>
+                  <div class='col-2 d-flex flex-column'>
+                    <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
+                  </div>
+                  <div class="col d-flex flex-column my-2">
+                    <h5 class="search-title"><%= result %></h5>
+                    <div>
+                      <% result.displayed_tags.each do |tag| %>
+                        <span class="badge bg-primary"><%= tag %></span>
+                      <% end %>
                     </div>
                   </div>
-                </a>
+                </div>
+              </a>
 
-              <% end %>
-            <% else %>
-              <span class="suggestions fst-italic text-muted">"Room for working"</span>
-              <span class="suggestions fst-italic text-muted">"I am hungry"</span>
-              <span class="suggestions fst-italic text-muted">"Where is prof. Meinel?"</span>
             <% end %>
-          </div>
+          <% else %>
+            <span class="suggestions fst-italic text-muted">"Room for working"</span>
+            <span class="suggestions fst-italic text-muted">"I am hungry"</span>
+            <span class="suggestions fst-italic text-muted">"Where is prof. Meinel?"</span>
+          <% end %>
+        </div>
 
-          <br>
+        <br>
 
-          <%if @exact_results.present? and @more_results.present? %> Similar Results <%end %>
-          <div class="list-group" id="similar-results">
-            <%if @more_results.present? %>
-              <% @more_results.each do |result|%>
+        <%if @exact_results.present? and @more_results.present? %> Similar Results <%end %>
+        <div class="list-group" id="similar-results">
+          <%if @more_results.present? %>
+            <% @more_results.each do |result|%>
 
-                <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
-                  <div class='row'>
-                    <div class='col-2 d-flex flex-column'>
-                      <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
-                    </div>
-                    <div class="col d-flex flex-column my-2">
-                      <h5 class="search-title"><%= result %></h5>
-                      <div>
-                        <% result.displayed_tags.each do |tag| %>
-                          <span class="badge bg-primary"><%= tag %></span>
-                        <% end %>
-                      </div>
+              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
+                <div class='row'>
+                  <div class='col-2 d-flex flex-column'>
+                    <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
+                  </div>
+                  <div class="col d-flex flex-column my-2">
+                    <h5 class="search-title"><%= result %></h5>
+                    <div>
+                      <% result.displayed_tags.each do |tag| %>
+                        <span class="badge bg-primary"><%= tag %></span>
+                      <% end %>
                     </div>
                   </div>
-                </a>
+                </div>
+              </a>
 
-              <% end %>
             <% end %>
-          </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,62 +2,73 @@
 
 <%= javascript_pack_tag 'search', 'data-turbolinks-track': 'reload' %>
 <body onload="textEntered();">
-<div class="row">
-  <div class="col-lg-6 col-md-9 col-12 mx-auto">
+<div class="searchpage d-flex justify-content-center flex-column">
+  <div class="row">
+    <div class="col-lg-6 col-md-9 col-12 mx-auto">
 
-    <%= render('partials/search_bar', :locals => {:path => search_path}) %>
+      <div style="text-align:center">
+      <img src="/images/platypus.png" alt="Logo" width="244" height="115">
+      <h2 class="fw-light"></h2>
+      </div>
 
-    <div class="row">
-      <div class="col">
-        <div class="list-group" id="exact-results">
-          <%if @exact_results.present? %>
-            <% @exact_results.each do |result|%>
+      <%= render('partials/search_bar', :locals => {:path => search_path}) %>
 
-              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
-                <div class='row'>
-                  <div class='col-2 d-flex flex-column'>
-                    <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
-                  </div>
-                  <div class="col d-flex flex-column my-2">
-                    <h5 class="search-title"><%= result %></h5>
-                    <div>
-                      <% result.displayed_tags.each do |tag| %>
-                        <span class="badge bg-primary"><%= tag %></span>
-                      <% end %>
+      <div class="row">
+        <div class="col">
+          <div class="list-group" id="exact-results">
+            <%if @exact_results.present? %>
+              <% @exact_results.each do |result|%>
+
+                <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
+                  <div class='row'>
+                    <div class='col-2 d-flex flex-column'>
+                      <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
+                    </div>
+                    <div class="col d-flex flex-column my-2">
+                      <h5 class="search-title"><%= result %></h5>
+                      <div>
+                        <% result.displayed_tags.each do |tag| %>
+                          <span class="badge bg-primary"><%= tag %></span>
+                        <% end %>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </a>
+                </a>
 
+              <% end %>
+            <% else %>
+              <span class="suggestions fst-italic text-muted">"Room for working"</span>
+              <span class="suggestions fst-italic text-muted">"I am hungry"</span>
+              <span class="suggestions fst-italic text-muted">"Where is prof. Meinel?"</span>
             <% end %>
-          <% end %>
-        </div>
+          </div>
 
-        <br>
+          <br>
 
-        <%if @exact_results.present? and @more_results.present? %> Similar Results <%end %>
-        <div class="list-group" id="similar-results">
-          <%if @more_results.present? %>
-            <% @more_results.each do |result|%>
+          <%if @exact_results.present? and @more_results.present? %> Similar Results <%end %>
+          <div class="list-group" id="similar-results">
+            <%if @more_results.present? %>
+              <% @more_results.each do |result|%>
 
-              <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
-                <div class='row'>
-                  <div class='col-2 d-flex flex-column'>
-                    <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
-                  </div>
-                  <div class="col d-flex flex-column my-2">
-                    <h5 class="search-title"><%= result %></h5>
-                    <div>
-                      <% result.displayed_tags.each do |tag| %>
-                        <span class="badge bg-primary"><%= tag %></span>
-                      <% end %>
+                <a href="<%=url_for(result)%>" class="list-group-item list-group-item-action search-item">
+                  <div class='row'>
+                    <div class='col-2 d-flex flex-column'>
+                      <%= image_tag(result.image_or_placeholder, class: "picture-rounded md") %>
+                    </div>
+                    <div class="col d-flex flex-column my-2">
+                      <h5 class="search-title"><%= result %></h5>
+                      <div>
+                        <% result.displayed_tags.each do |tag| %>
+                          <span class="badge bg-primary"><%= tag %></span>
+                        <% end %>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </a>
+                </a>
 
+              <% end %>
             <% end %>
-          <% end %>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #213.
![Screenshot_1](https://user-images.githubusercontent.com/41285083/152828681-49f6907c-8153-4d30-b71d-ef2f17a233bf.png)

This PR centers the search vertically. 
Currently, search results will be centered as well resulting the whole page to become unusable.
Therefore this should only be merged together with #214 which should remove the `.search` class when focusing the search bar.